### PR TITLE
DO NOT MERGE Dops 3438 modify the sonar jenkins plugin

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.1/apache-maven-3.8.1-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/CARPE_README.md
+++ b/CARPE_README.md
@@ -12,10 +12,33 @@ Our Jenkins UI is getting locked on multi-branch pipelines after some indetermin
 1. test on Green Jenkins
 1. deploy to SDLC Jenkins
 
-## Building
+## Building and Publishing
+
+Because this is such a one-off emergency band-aid kind of thing, we are willing to just build this locally and push it up to S3.
+
+When in S3, our Jenkins AMI build process will pull it down and then install our customized plugin into the Jenkins image.
+
+To build this, run the following:
 ```bash
-$ git clone git@github.com:carpe/devops-sonar-scanner-jenkins.git
-$ cd devops-sonar-scanner-jenkins
-$ git checkout  DOPS-3438-modify-the-sonar-jenkins-plugin
-$ ./mvnw clean install -Dmaven.test.skip=true
+git clone git@github.com:carpe/devops-sonar-scanner-jenkins.git
+cd devops-sonar-scanner-jenkins
+git checkout  DOPS-3438-modify-the-sonar-jenkins-plugin
+./mvnw clean install -Dmaven.test.skip=true
 ```
+The compile may take a while.
+
+This will result in a file called `sonar.hpi` in the `target` directory.
+This is the file we will publish to S3.
+```bash
+VERSION="2.15.6"
+aws s3 cp target/sonar.hpi s3://carpe-jenkins/plugins/${VERSION}/sonar.hpi
+```
+
+After publishing the plugin, you will need to go to the Jenkins project and [change the location in S3 that the plugin is being pulled from](https://github.com/carpe/devops-jenkins/blob/d0d2d689daac5e671c1599ed9bfc2beb89ed46ed/ami-creation/jenkins-controller/files/configure-jenkins.sh#L50-L51) to match the version that you just published.
+You can then create a new AMI to make sure that the next Jenkins you deploy will have this plugin in it.
+
+## Testing
+
+To test whether the plugin works without actually publishing it and rebuilding an AMI, you can create a new green Jenkins.
+After creating the green Jenkins, you can upload this plugin manually using the Deploy Plugin feature in the [Plugin Advanced Settings page](https://jenkins-controller-green.ss.carpe.io/manage/pluginManager/advanced).
+You may need to restart Jenkins for it to take effect. This can be done on [the Restart page](https://jenkins-controller-green.ss.carpe.io/restart).

--- a/CARPE_README.md
+++ b/CARPE_README.md
@@ -1,0 +1,21 @@
+# DEVOPS' Sonarcloud Plugin README
+
+## Background
+Our Jenkins UI is getting locked on multi-branch pipelines after some indeterminent abount of time.  The assumption is we’re getting throttled by a non-authenticated call to the API https://sonarcloud/api/server/version.  We want to try modifying the plugin to hard-code this return value from this call, thus eliminating this throttling.
+
+## Acceptance Criteria
+1. fork the repo to Carpe
+1. clone locally
+1. create branch `DOPS-3438-modify-the-sonar-jenkins-plugin` from Tag `sonar-2.15`
+1. modify the getServerVersion call to return “8.0.0.44909“
+1. modify the POM to show version 2.15.4
+1. test on Green Jenkins
+1. deploy to SDLC Jenkins
+
+## Building
+```bash
+$ git clone git@github.com:carpe/devops-sonar-scanner-jenkins.git
+$ cd devops-sonar-scanner-jenkins
+$ git checkout  DOPS-3438-modify-the-sonar-jenkins-plugin
+$ ./mvnw clean install -Dmaven.test.skip=true
+```

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>sonar</artifactId>
-  <version>2.15</version>
+  <version>2.15.4</version>
   <packaging>hpi</packaging>
 
   <name>SonarQube Scanner for Jenkins</name>

--- a/src/main/java/hudson/plugins/sonar/client/WsClient.java
+++ b/src/main/java/hudson/plugins/sonar/client/WsClient.java
@@ -19,6 +19,7 @@
  */
 package hudson.plugins.sonar.client;
 
+import hudson.plugins.sonar.utils.Logger;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import javax.annotation.CheckForNull;
@@ -79,7 +80,9 @@ public class WsClient {
   }
 
   public String getServerVersion() {
-    return client.getHttp(serverUrl + API_VERSION, null);
+    Logger.LOG.info("Using special build Carpe Data plugin...");
+    return "8.0.0.44909";
+    //return client.getHttp(serverUrl + API_VERSION, null);
   }
 
   private static String encode(String param) {


### PR DESCRIPTION
**Background:**
Jenkins UI is getting locked on multi-branch pipelines after some time.  The assumption is we’re getting throttled by a non-authenticated call to the API https://sonarcloud/api/server/version.  We want to try modifying the plugin to hard-code this return value from this call, thus eliminating this throttling.

**Acceptance Criteria:** 
modify the getServerVersion call to return “8.0.0.44909“
modify the POM to show version 2.15.4

**building detailed in CARPE_README.md**
